### PR TITLE
Fix default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 |---------|----------|--------------------------------------------|---------|------------------|
 | token   | Yes      | ICQ API token                              |         | _&lt;String&gt;_ |
 | to      | Yes      | Recipient. Can be chat id or user nickname |         | _&lt;String&gt;_ |
-| message | No       | Text message                               | `null`  | _&lt;String&gt;_ |
-| file    | No       | File message                               | `null`  | _&lt;String&gt;_ |
+| message | No       | Text message                               |         | _&lt;String&gt;_ |
+| file    | No       | File message                               |         | _&lt;String&gt;_ |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,9 @@ inputs:
   message:
     description: 'Text message'
     required: false
-    default: "null"
   file:
     description: 'File message'
     required: false
-    default: "null"
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Replace default values to avoid null errors when sending messages.

If the file is 'null', an error about the absence of file "null" is generated. Similarly for the message field, when sending only a file, the message field will have a value of "null".